### PR TITLE
Fixes and enhancements

### DIFF
--- a/zmakebas.c
+++ b/zmakebas.c
@@ -1165,7 +1165,7 @@ int main(int argc, char *argv[]) {
                     memcpy(outptr, ptr, ptr2 - ptr);
                     outptr += ptr2 - ptr;
 
-					if ( zx81mode || ( ptr[-1] != '$' && ptr[-1] != '@' ) ) {											// :dbolli:20200417 19:36:10 Don't insert 5 byte inline FP for ZX Spectrum Next $nnnn hex num and @nnn binary num
+					if ( zx81mode || ( ptr[-1] != '$' && ptr[-1] != '@' && !isalnum(ptr[-1]) ) ) {											// :dbolli:20200417 19:36:10 Don't insert 5 byte inline FP for ZX Spectrum Next $nnnn hex num and @nnn binary num
 						
 						*outptr++ = zx81mode ? 0x7e : 0x0e;
 					

--- a/zmakebas.c
+++ b/zmakebas.c
@@ -912,8 +912,8 @@ int main(int argc, char *argv[]) {
                      * <>, <=, >=.
                      */
                     if ((*tarrptr)[0] == '<' || (*tarrptr)[1] == '=' ||
-                            (!isalpha(ptr[-1]) && !isalpha(ptr[toklen]) && !( !zx81mode && ( toknum == PEEK_TOKEN_NUM ) && ( ptr[toklen] == '$' )))		// :dbolli:20200420 18:54:45 Added check for PEEK that is actually PEEK$ (v1.5.2)
-                            && toknum >= 135) {		// :dbolli:20200331 14:48:51 Changed from toknum > 150 to include ZX Spectrum Next keywords (v1.5.2)
+                            ((!isalpha(ptr[-1]) && !isalpha(ptr[toklen]) && !( !zx81mode && ( toknum == PEEK_TOKEN_NUM ) && ( ptr[toklen] == '$' )))		// :dbolli:20200420 18:54:45 Added check for PEEK that is actually PEEK$ (v1.5.2)
+                            && toknum >= 135)) {		// :dbolli:20200331 14:48:51 Changed from toknum > 150 to include ZX Spectrum Next keywords (v1.5.2)
                         ptr2 = linestart + (ptr - lcasebuf);
                         /* the token text is overwritten in the lcase copy too, to
                          * avoid problems with e.g. go to/to.

--- a/zmakebas.c
+++ b/zmakebas.c
@@ -963,7 +963,7 @@ int main(int argc, char *argv[]) {
                     for (f = 0; f < labelend; f++) {
                         int len = strlen(labels[f]);
                         if (memcmp(labels[f], ptr, len) == 0 &&
-                                (ptr[len] < 33 || ptr[len] > 126 || ptr[len] == ':')) {
+                                (ptr[len] < 33 || ptr[len] > 126 || ispunct(ptr[len]))) {
                             unsigned char numbuf[20];
 
                             /* this could be optimised to use a single memmove(), but

--- a/zmakebas.c
+++ b/zmakebas.c
@@ -1302,7 +1302,7 @@ int main(int argc, char *argv[]) {
 			headerbuf[47]= 0xbc;                      // PR_CC
 			headerbuf[48]= 33;                        // S_POSN
 			headerbuf[49]= 24;
-			headerbuf[50]= 0x0b01000000;                // CDFLAG
+			headerbuf[50]= 0b01000000;                // CDFLAG
 
 			/* write header */
 			fwrite( headerbuf, 1, 0x74, out );

--- a/zmakebas.c
+++ b/zmakebas.c
@@ -1199,7 +1199,11 @@ int main(int argc, char *argv[]) {
 							in_deffn= 0;
 						else if ( *ptr == ',' || *ptr == ')' )
 							*outptr++= 0x0e,
-							*outptr++= *outptr++= *outptr++= *outptr++= *outptr++= 0,
+							*outptr++= 0,
+							*outptr++= 0,
+							*outptr++= 0,
+							*outptr++= 0,
+							*outptr++= 0,
 							*outptr++= *ptr++;
 						if( *ptr != ' ' )
 							*outptr++= *ptr++;


### PR DESCRIPTION
This pull request fixes some issues with the current version of `zmakebas` and adds one useful new feature.

### Bugs fixed

If we said:
```
LET Level42 = 7
```
It would mistakenly turn `42` into a number. BASIC would ignore the spurious number but other things would be confused by it.

If we said:
```
DATA "Wow", @someRoutine, "Cool"
```
we'd get a label not found error, as it'd tack the comma onto the name `someRoutine`.

### New Feature

You can now specify a line number in labels mode.  This can be useful when defining subroutines that we want to be at specific locations. You can also write:

```
9000+2 DATA "Blah"
DATA "Foo"
DATA "Bat"
```

to tell it to start at `9000` and increment by `2` for subsequent lines.