### PR TITLE
Fix for ZX81 mode character code number escapes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-01-17 ryangray
+        * Fix ZX81 mode escape byte codes in input so they are not translated from ASCII
+        * Version 1.8.1
+		 
 2023-01-01 imneme
         * Fix handling of numbers in variable names
         * Fix labels in data statements

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ zmakebas.guide: zmakebas.1
 
 # The stuff below makes the distribution tgz.
 
-VERS=1.7.2
+VERS=1.8.1
 
 dist: tgz
 tgz: ../zmakebas-$(VERS).tar.gz

--- a/Makefile.68k
+++ b/Makefile.68k
@@ -38,7 +38,7 @@ zmakebas.guide: zmakebas.1
 
 # The stuff below makes the distribution tgz.
 
-VERS=1.7.2
+VERS=1.8.1
 
 dist: tgz
 tgz: ../zmakebas-$(VERS).tar.gz

--- a/examples/zx81-basic-demo-lbl.bas
+++ b/examples/zx81-basic-demo-lbl.bas
@@ -6,14 +6,21 @@
 #
 # See `demolbl.bas' for a label-using version.
 
+# Machine code test. The codes 1 and 201 should not get translated by the ASCII
+# to ZX81 character mapping, but if it is mis-applied, then the two bytes in-
+# between may get changed.
+
+    rem MACHINE CODE:\{1}\{40}\{65}\{201}
 
 	rem zmakebas demo
 
 # tabs (as below) are fine (they're removed)
 #	let HEADER=	2000
 #	let BLOCKDEM=4000
+#   let MCTEST  =5000
 
 	gosub @header
+	gosub @mctest
 	gosub @blockdem
 	stop
 
@@ -51,3 +58,14 @@
 	print at 17,0;"\   \'  \ ' \'' \.  \:  \.' \:' \!: \!. \!'",,, \
 		   TAB 0; "\:: \.: \:. \.. \': \ : \'. \ . \|: \|. \|'"
 	return
+
+@mctest:
+
+    let REF=65*256+40
+    print "MC RESULT SHOULD BE "; REF;"."
+    let MC= usr 16527
+    print "THE MC RESULT IS ";MC;"."
+    print "ESCAPE CODE TEST ";
+    if MC<>REF then print "FAIL."
+    if MC=REF then print "PASS."
+    return

--- a/examples/zx81-basic-demo.bas
+++ b/examples/zx81-basic-demo.bas
@@ -60,6 +60,8 @@
 		   TAB 0; "\:: \.: \:. \.. \': \ : \'. \ . \|: \|. \|'"
 4150 return
 
+# mctest
+
 5010 let REF=65*256+40
 5020 print "MC RESULT SHOULD BE "; REF;"."
 5030 let MC= usr 16527

--- a/examples/zx81-basic-demo.bas
+++ b/examples/zx81-basic-demo.bas
@@ -6,14 +6,21 @@
 #
 # See `demolbl.bas' for a label-using version.
 
+# Machine code test. The codes 1 and 201 should not get translated by the ASCII
+# to ZX81 character mapping, but if it is mis-applied, then the two bytes in-
+# between may get changed.
+
+1 REM MACHINE CODE:\{1}\{40}\{65}\{201}
 
 10 rem zmakebas demo
 
 # tabs (as below) are fine (they're removed)
 20 let HEADER=	2000
 25 let BLOCKDEM=4000
+30 let MCTEST  =5000
 
 40 gosub HEADER
+50 gosub MCTEST
 60 gosub BLOCKDEM
 70 stop
 
@@ -52,3 +59,12 @@
 4140 print at 17,0;"\   \'  \ ' \'' \.  \:  \.' \:' \!: \!. \!'",,, \
 		   TAB 0; "\:: \.: \:. \.. \': \ : \'. \ . \|: \|. \|'"
 4150 return
+
+5010 let REF=65*256+40
+5020 print "MC RESULT SHOULD BE "; REF;"."
+5030 let MC= usr 16527
+5040 print "THE MC RESULT IS ";MC;"."
+5050 print "ESCAPE CODE TEST ";
+5060 if MC<>REF then print "FAIL."
+5070 if MC=REF then print "PASS."
+5080 return

--- a/zmakebas.1
+++ b/zmakebas.1
@@ -5,7 +5,7 @@
 .\"
 .\" zmakebas.1 - man page
 .\"
-.TH zmakebas 1 "3rd January, 2023" "Version 1.8.0" "Retrocomputing Tools"
+.TH zmakebas 1 "17th January, 2023" "Version 1.8.1" "Retrocomputing Tools"
 .\"
 .\"------------------------------------------------------------------
 .\"

--- a/zmakebas.c
+++ b/zmakebas.c
@@ -22,7 +22,7 @@
 #define MSDOS
 #endif
 
-#define VERSION          	"1.8.0"
+#define VERSION          	"1.8.1"
 #define DEFAULT_OUTPUT		"out.tap"
 #define REM_TOKEN_NUM		234
 #define PEEK_TOKEN_NUM		190						// :dbolli:20200420 19:00:13 Added ZX Spectrum PEEK token code (v1.5.2)

--- a/zmakebas.c
+++ b/zmakebas.c
@@ -1215,7 +1215,10 @@ int main(int argc, char *argv[]) {
                     }
 
                     /* output text of number */
-                    memcpy(outptr, ptr, ptr2 - ptr);
+                    if (zx81mode) /* translate and copy ASCII chars to ZX81 */
+                        memcpycnv((char *)outptr, (char *)ptr, ptr2 - ptr);
+                    else
+                        memcpy(outptr, ptr, ptr2 - ptr);
                     outptr += ptr2 - ptr;
 
 					if ( zx81mode || ( ptr[-1] != '$' && ptr[-1] != '@' && !isalnum(ptr[-1]) ) ) {											// :dbolli:20200417 19:36:10 Don't insert 5 byte inline FP for ZX Spectrum Next $nnnn hex num and @nnn binary num
@@ -1263,11 +1266,14 @@ int main(int argc, char *argv[]) {
 					}
 				else
                     /* if not number, just output char */
-                    *outptr++ = *ptr++;
+                    if (zx81mode) /* translate and copy ASCII char to ZX81 */
+                        memcpycnv((char *)outptr++, (char *)ptr++, 1);
+                    else
+                        *outptr++ = *ptr++;
                 }
             }
 
-            *outptr++ = 0x0d; /* add terminating CR */
+            *outptr++ = zx81mode ? 0x76 : 0x0d; /* add terminating CR */
 
             /* output line */
             linelen = outptr - outbuf;
@@ -1284,10 +1290,7 @@ int main(int argc, char *argv[]) {
             *fileptr++ = (linenum & 255);
             *fileptr++ = (linelen & 255);
             *fileptr++ = (linelen >> 8);
-			if( zx81mode )
-				memcpycnv( (char *)fileptr, (char *)outbuf, linelen );
-			else
-				memcpy(fileptr, outbuf, linelen);
+            memcpy(fileptr, outbuf, linelen); // Any zx81mode translations are already done
             fileptr += linelen;
 
         } /* end of pass-making while() */

--- a/zmakebas.rc
+++ b/zmakebas.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,7,2,0
- PRODUCTVERSION 1,7,2,0
+ FILEVERSION 1,8,1,0
+ PRODUCTVERSION 1,8,1,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -68,12 +68,12 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription", "zmakebas"
-            VALUE "FileVersion", "1.7.2.0"
+            VALUE "FileVersion", "1.8.1.0"
             VALUE "InternalName", "zmakebas.exe"
-            VALUE "LegalCopyright", "Copyright (C) 2022"
+            VALUE "LegalCopyright", "Copyright (C) 2023"
             VALUE "OriginalFilename", "zmakebas.exe"
             VALUE "ProductName", "zmakebas"
-            VALUE "ProductVersion", "1.7.2.0"
+            VALUE "ProductVersion", "1.8.1.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/zmakebas.readme
+++ b/zmakebas.readme
@@ -2,7 +2,7 @@ Short:        BASIC Text to ZX Spectrum/ZX81 .TAP/.P
 Uploader:     chris@unsatisfactorysoftware.co.uk (Chris Young)
 Author:       Russell Marks and others
 Type:         util/conv
-Version:      1.8.0
+Version:      1.8.1
 Architecture: m68k-amigaos >= 2.0.4; ppc-amigaos >= 4.0.0
 
 Quick port/recompile of zmakebas.
@@ -12,6 +12,11 @@ The only change is the inclusion of documentation in AmigaGuide
 format.
 
 Changelog:
+
+2023-01-17 ryangray
+        * Fix ZX81 mode escape byte codes in input so they are not translated from ASCII
+        * Version 1.8.1
+
 2023-01-01 imneme
          * Fix handling of numbers in variable names
          * Fix labels in data statements


### PR DESCRIPTION
The feature of specifying literal byte codes by putting the value in
curly braces with a backslash before it `\{123}` was translating some of the
codes when it shouldn't through the `memcpycnv` call at the end. Since other
special handling was already producing final byte codes, it seemed
simpler to just also translate the other characters as we go and not
translate at the end. Added an example in the ZX81 demo that produces a
tiny machine code routine that it calls to test for correct translation.