### PR TITLE
Fix translation of backtick to the quote image token for ZX81

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-01-28 ryangray
+        * Fix translation of backtick to the quote image token
+        * Remove VAL$ from ZX81 tokens list
+        * Version 1.8.2
+
 2023-01-17 ryangray
         * Fix ZX81 mode escape byte codes in input so they are not translated from ASCII
         * Version 1.8.1

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ zmakebas.guide: zmakebas.1
 
 # The stuff below makes the distribution tgz.
 
-VERS=1.8.1
+VERS=1.8.2
 
 dist: tgz
 tgz: ../zmakebas-$(VERS).tar.gz

--- a/Makefile.68k
+++ b/Makefile.68k
@@ -38,7 +38,7 @@ zmakebas.guide: zmakebas.1
 
 # The stuff below makes the distribution tgz.
 
-VERS=1.8.1
+VERS=1.8.2
 
 dist: tgz
 tgz: ../zmakebas-$(VERS).tar.gz

--- a/examples/zx81-basic-demo-lbl.bas
+++ b/examples/zx81-basic-demo-lbl.bas
@@ -17,11 +17,13 @@
 # tabs (as below) are fine (they're removed)
 #	let HEADER=	2000
 #	let BLOCKDEM=4000
+#   let OTHER   =4500
 #   let MCTEST  =5000
 
 	gosub @header
-	gosub @mctest
 	gosub @blockdem
+    gosub @other
+	gosub @mctest
 	stop
 
 # init
@@ -35,16 +37,15 @@
 	print "  NON-ASCII CHARS IN ZMAKEBAS  "
 	print "\''\''\''\''\''\''\''\''\''\''\''\''\''\''\''\''";\
 	         "\''\''\''\''\''\''\''\''\''\''\''\''\''\''\''"
-	print
 	return
 
 @blockdem:
 
 #                   01234567890123456789012345678901
-	print at 9,0;"THE BLOCK GRAPHICS, FIRST AS ";\
+	print "THE BLOCK GRAPHICS, FIRST AS ";\
 		   "LISTED BY A FOR..NEXT LOOP, THEN ";\
 		   "VIA ZMAKEBAS\"S ESCAPE SEQUENCES:"
-	print at 13,0;
+	print
 	for F=0 to 10
 	print chr$(F);" ";
 	next F
@@ -55,9 +56,19 @@
 	next F
 	print
 	print
-	print at 17,0;"\   \'  \ ' \'' \.  \:  \.' \:' \!: \!. \!'",,, \
+	print "\   \'  \ ' \'' \.  \:  \.' \:' \!: \!. \!'",,, \
 		   TAB 0; "\:: \.: \:. \.. \': \ : \'. \ . \|: \|. \|'"
 	return
+
+# Other escapes or characers
+
+@other:
+    print
+    print "DOUBLE-BACKSLASH FOR POUND : \\"
+    print "BACKSLASH-AT FOR INV. POUND: \@"
+    print "BACKTICK FOR QUOTE IMAGE   : `"
+    print
+    return
 
 @mctest:
 

--- a/examples/zx81-basic-demo.bas
+++ b/examples/zx81-basic-demo.bas
@@ -17,12 +17,14 @@
 # tabs (as below) are fine (they're removed)
 20 let HEADER=	2000
 25 let BLOCKDEM=4000
+26 let OTHER   =4500
 30 let MCTEST  =5000
 
 40 gosub HEADER
-50 gosub MCTEST
-60 gosub BLOCKDEM
-70 stop
+50 gosub BLOCKDEM
+60 gosub OTHER
+70 gosub MCTEST
+80 stop
 
 # init
 
@@ -35,30 +37,37 @@
 2010 print "  NON-ASCII CHARS IN ZMAKEBAS  "
 2020 print "\''\''\''\''\''\''\''\''\''\''\''\''\''\''\''\''";\
 	         "\''\''\''\''\''\''\''\''\''\''\''\''\''\''\''"
-2030 print
-2040 return
+2030 return
 
 # blockdem
 
 #                   01234567890123456789012345678901
-4000 print at 9,0;"THE BLOCK GRAPHICS, FIRST AS ";\
+4000 print "THE BLOCK GRAPHICS, FIRST AS ";\
 		   "LISTED BY A FOR..NEXT LOOP, THEN ";\
 		   "VIA ZMAKEBAS\"S ESCAPE SEQUENCES:"
-4020 print at 13,0;
+4020 print
 4030 for F=0 to 10
 4040 print chr$(F);" ";
 4050 next F
 4060 print
 4070 print
-4080 print at 15,0;
 4090 for F=128 to 138
 4100 print chr$(F);" ";
 4110 next F
 4120 print
 4130 print
-4140 print at 17,0;"\   \'  \ ' \'' \.  \:  \.' \:' \!: \!. \!'",,, \
+4140 print "\   \'  \ ' \'' \.  \:  \.' \:' \!: \!. \!'",,, \
 		   TAB 0; "\:: \.: \:. \.. \': \ : \'. \ . \|: \|. \|'"
 4150 return
+
+# Other escapes or characers
+
+4500 print
+4510 print "DOUBLE-BACKSLASH FOR POUND : \\"
+4520 print "BACKSLASH-AT FOR INV. POUND: \@"
+4530 print "BACKTICK FOR QUOTE IMAGE   : `"
+4540 print
+4550 return
 
 # mctest
 

--- a/zmakebas.1
+++ b/zmakebas.1
@@ -5,7 +5,7 @@
 .\"
 .\" zmakebas.1 - man page
 .\"
-.TH zmakebas 1 "17th January, 2023" "Version 1.8.1" "Retrocomputing Tools"
+.TH zmakebas 1 "28th January, 2023" "Version 1.8.2" "Retrocomputing Tools"
 .\"
 .\"------------------------------------------------------------------
 .\"

--- a/zmakebas.c
+++ b/zmakebas.c
@@ -22,7 +22,7 @@
 #define MSDOS
 #endif
 
-#define VERSION          	"1.8.1"
+#define VERSION          	"1.8.2"
 #define DEFAULT_OUTPUT		"out.tap"
 #define REM_TOKEN_NUM		234
 #define PEEK_TOKEN_NUM		190						// :dbolli:20200420 19:00:13 Added ZX Spectrum PEEK token code (v1.5.2)
@@ -264,10 +264,10 @@ char *tokens81[]={
   "len", "",
   "val", "",
   "code", "",
-  "val$", "",
+  "", "",
   "tab", "",
   "at", "",
-  "`", "",
+  "", "",
   "pi", "",
   "inkey$", "",
   "rnd", "",
@@ -385,6 +385,7 @@ void memcpycnv(char *dst, char *src, size_t num) {
       case 0x3d: *(dst++) = 0x14; break; // =
       case 0x3e: *(dst++) = 0x12; break; // >
       case 0x3f: *(dst++) = 0x0f; break; // ?
+      case 0x60: *(dst++) = 0xc0; break; // Backtick (`) to Quote Image
       case 0x7c: *(dst++) = 0x41; break; // INKEY$
       case 0x7d: *(dst++) = 0x40; break; // RND
       case 0x7e: *(dst++) = in; // number

--- a/zmakebas.rc
+++ b/zmakebas.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,8,1,0
- PRODUCTVERSION 1,8,1,0
+ FILEVERSION 1,8,2,0
+ PRODUCTVERSION 1,8,2,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -68,12 +68,12 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription", "zmakebas"
-            VALUE "FileVersion", "1.8.1.0"
+            VALUE "FileVersion", "1.8.2.0"
             VALUE "InternalName", "zmakebas.exe"
             VALUE "LegalCopyright", "Copyright (C) 2023"
             VALUE "OriginalFilename", "zmakebas.exe"
             VALUE "ProductName", "zmakebas"
-            VALUE "ProductVersion", "1.8.1.0"
+            VALUE "ProductVersion", "1.8.2.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/zmakebas.readme
+++ b/zmakebas.readme
@@ -2,7 +2,7 @@ Short:        BASIC Text to ZX Spectrum/ZX81 .TAP/.P
 Uploader:     chris@unsatisfactorysoftware.co.uk (Chris Young)
 Author:       Russell Marks and others
 Type:         util/conv
-Version:      1.8.1
+Version:      1.8.2
 Architecture: m68k-amigaos >= 2.0.4; ppc-amigaos >= 4.0.0
 
 Quick port/recompile of zmakebas.
@@ -12,6 +12,11 @@ The only change is the inclusion of documentation in AmigaGuide
 format.
 
 Changelog:
+
+2023-01-28 ryangray
+        * Fix translation of backtick to the quote image token
+        * Remove VAL$ from ZX81 tokens list
+        * Version 1.8.2
 
 2023-01-17 ryangray
         * Fix ZX81 mode escape byte codes in input so they are not translated from ASCII


### PR DESCRIPTION
- The token recognizer logic doesn't recognize tokens in REMs and quoted strings which is where the quote image would be used, so removed it from the tokens list and added it to the ZX81 character translation routine.
- Added demos for pound, inverse pound, and quote image to ZX81 demo 
- Also removed VAL$ from the ZX81 tokens as it does not have that function.
- Version 1.8.2