### PR TITLE
Fix bug not ending the in_deffn condition

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-07-07 ryangray
+        * Fix bug not ending the in_deffn condition which would produce a bad 
+          line or cause zmakebas to hang.
+
 2023-04-15 ryangray
         * Fix "-num" or "+num" following a number leaving out the FP bytes after "num"
         * Version 1.8.3

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ zmakebas.guide: zmakebas.1
 
 # The stuff below makes the distribution tgz.
 
-VERS=1.8.3
+VERS=1.8.4
 
 dist: tgz
 tgz: ../zmakebas-$(VERS).tar.gz

--- a/Makefile.68k
+++ b/Makefile.68k
@@ -38,7 +38,7 @@ zmakebas.guide: zmakebas.1
 
 # The stuff below makes the distribution tgz.
 
-VERS=1.8.3
+VERS=1.8.4
 
 dist: tgz
 tgz: ../zmakebas-$(VERS).tar.gz

--- a/zmakebas.1
+++ b/zmakebas.1
@@ -5,7 +5,7 @@
 .\"
 .\" zmakebas.1 - man page
 .\"
-.TH zmakebas 1 "15th April, 2023" "Version 1.8.3" "Retrocomputing Tools"
+.TH zmakebas 1 "7th July, 2023" "Version 1.8.4" "Retrocomputing Tools"
 .\"
 .\"------------------------------------------------------------------
 .\"

--- a/zmakebas.c
+++ b/zmakebas.c
@@ -22,7 +22,7 @@
 #define MSDOS
 #endif
 
-#define VERSION          	"1.8.3"
+#define VERSION          	"1.8.4"
 #define DEFAULT_OUTPUT		"out.tap"
 #define REM_TOKEN_NUM		234
 #define PEEK_TOKEN_NUM		190						// :dbolli:20200420 19:00:13 Added ZX Spectrum PEEK token code (v1.5.2)
@@ -1253,15 +1253,14 @@ int main(int argc, char *argv[]) {
 					/* special def fn case */
 					if ( in_deffn ) {
 						if( *ptr == '=' )
-							in_deffn= 0;
+							in_deffn = 0; /* Finished with the formal parameters */
 						else if ( *ptr == ',' || *ptr == ')' )
-							*outptr++= 0x0e,
+							*outptr++= 0x0e, /*  Insert inline Floating Point placeholder after each formal parameter */
 							*outptr++= 0,
 							*outptr++= 0,
 							*outptr++= 0,
 							*outptr++= 0,
-							*outptr++= 0,
-							*outptr++= *ptr++;
+							*outptr++= 0;
 						if( *ptr != ' ' )
 							*outptr++= *ptr++;
 					}

--- a/zmakebas.rc
+++ b/zmakebas.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,8,3,0
- PRODUCTVERSION 1,8,3,0
+ FILEVERSION 1,8,4,0
+ PRODUCTVERSION 1,8,4,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -68,12 +68,12 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription", "zmakebas"
-            VALUE "FileVersion", "1.8.3.0"
+            VALUE "FileVersion", "1.8.4.0"
             VALUE "InternalName", "zmakebas.exe"
             VALUE "LegalCopyright", "Copyright (C) 2023"
             VALUE "OriginalFilename", "zmakebas.exe"
             VALUE "ProductName", "zmakebas"
-            VALUE "ProductVersion", "1.8.3.0"
+            VALUE "ProductVersion", "1.8.4.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/zmakebas.readme
+++ b/zmakebas.readme
@@ -2,7 +2,7 @@ Short:        BASIC Text to ZX Spectrum/ZX81 .TAP/.P
 Uploader:     chris@unsatisfactorysoftware.co.uk (Chris Young)
 Author:       Russell Marks and others
 Type:         util/conv
-Version:      1.8.3
+Version:      1.8.4
 Architecture: m68k-amigaos >= 2.0.4; ppc-amigaos >= 4.0.0
 
 Quick port/recompile of zmakebas.
@@ -12,6 +12,10 @@ The only change is the inclusion of documentation in AmigaGuide
 format.
 
 Changelog:
+
+2023-07-07 ryangray
+        * Fix bug not ending the in_deffn condition which would produce a bad 
+          line or cause zmakebas to hang.
 
 2023-04-15 ryangray
         * Fix "-num" or "+num" following a number leaving out the FP bytes after "num"


### PR DESCRIPTION
The bug would produce a bad line since not ending the in_deffn condition caused it to place inline floating point placeholders before every comma and close-parentheses until the end of the line. Some lines could cause the program to hang. The block that added the inline FP bytes also copied the current character, but this copy was already being done in the next statement, so when getting to the right-paren, it would copy it, and the next statement would copy the '=', causing the later test for the '=' character to never be true to end the in_deffn condition unless '=' happened to appear later in the line. I just removed the extra character copy to let that happen on the next round of the while loop so the test for '=' will see it.