### PR TITLE
Fix number after + or - following $ not getting FP bytes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,12 @@
+2023-07-31 ryangray
+        * Fix bug of numbers after a + or - which followed a $ didn't include
+          the inline floating point bytes (such as: CODE a$-32)
+        * Version 1.8.5
+
 2023-07-07 ryangray
         * Fix bug not ending the in_deffn condition which would produce a bad 
           line or cause zmakebas to hang.
+        * Version 1.8.4
 
 2023-04-15 ryangray
         * Fix "-num" or "+num" following a number leaving out the FP bytes after "num"

--- a/Makefile.68k
+++ b/Makefile.68k
@@ -38,7 +38,7 @@ zmakebas.guide: zmakebas.1
 
 # The stuff below makes the distribution tgz.
 
-VERS=1.8.4
+VERS=1.8.5
 
 dist: tgz
 tgz: ../zmakebas-$(VERS).tar.gz

--- a/zmakebas.1
+++ b/zmakebas.1
@@ -5,7 +5,7 @@
 .\"
 .\" zmakebas.1 - man page
 .\"
-.TH zmakebas 1 "7th July, 2023" "Version 1.8.4" "Retrocomputing Tools"
+.TH zmakebas 1 "31st July, 2023" "Version 1.8.5" "Retrocomputing Tools"
 .\"
 .\"------------------------------------------------------------------
 .\"

--- a/zmakebas.c
+++ b/zmakebas.c
@@ -22,7 +22,7 @@
 #define MSDOS
 #endif
 
-#define VERSION          	"1.8.4"
+#define VERSION          	"1.8.5"
 #define DEFAULT_OUTPUT		"out.tap"
 #define REM_TOKEN_NUM		234
 #define PEEK_TOKEN_NUM		190						// :dbolli:20200420 19:00:13 Added ZX Spectrum PEEK token code (v1.5.2)
@@ -1198,11 +1198,10 @@ int main(int argc, char *argv[]) {
                  * representation). We do this largely by relying on strtod(),
                  * so that we only have to find the start - i.e. a non-alpha char,
                  * an optional `-' or `+', an optional `.', then a digit.
+                 * We start matching the number on first digit or a leading '.'
                  */
                 if (!in_rem && !in_quotes && !isalpha(ptr[-1]) && !isdigit(ptr[-1]) && 
-                        (isdigit(*ptr) ||
-                        ((*ptr == '-' || *ptr == '+' || *ptr == '.') && isdigit(ptr[1])) ||
-                        ((*ptr == '-' || *ptr == '+') && ptr[1] == '.' && isdigit(ptr[2])))) {
+                        (isdigit(*ptr) || (*ptr == '.' && isdigit(ptr[1])) )) {
                     if ( zx81mode || ptr[-1] != BIN_TOKEN_NUM)
                         /* we have a number. parse with strtod(). */
                         num = strtod(ptr, (char **) &ptr2);
@@ -1223,7 +1222,7 @@ int main(int argc, char *argv[]) {
                     outptr += ptr2 - ptr;
 
 					if ( zx81mode || ( ptr[-1] != '$' && ptr[-1] != '@' ) ) {											// :dbolli:20200417 19:36:10 Don't insert 5 byte inline FP for ZX Spectrum Next $nnnn hex num and @nnn binary num
-						
+
 						*outptr++ = zx81mode ? 0x7e : 0x0e;
 					
 						if ( *ptr2=='|' ) {

--- a/zmakebas.rc
+++ b/zmakebas.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,8,4,0
- PRODUCTVERSION 1,8,4,0
+ FILEVERSION 1,8,5,0
+ PRODUCTVERSION 1,8,5,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -68,12 +68,12 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription", "zmakebas"
-            VALUE "FileVersion", "1.8.4.0"
+            VALUE "FileVersion", "1.8.5.0"
             VALUE "InternalName", "zmakebas.exe"
             VALUE "LegalCopyright", "Copyright (C) 2023"
             VALUE "OriginalFilename", "zmakebas.exe"
             VALUE "ProductName", "zmakebas"
-            VALUE "ProductVersion", "1.8.4.0"
+            VALUE "ProductVersion", "1.8.5.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/zmakebas.readme
+++ b/zmakebas.readme
@@ -2,7 +2,7 @@ Short:        BASIC Text to ZX Spectrum/ZX81 .TAP/.P
 Uploader:     chris@unsatisfactorysoftware.co.uk (Chris Young)
 Author:       Russell Marks and others
 Type:         util/conv
-Version:      1.8.4
+Version:      1.8.5
 Architecture: m68k-amigaos >= 2.0.4; ppc-amigaos >= 4.0.0
 
 Quick port/recompile of zmakebas.
@@ -13,9 +13,15 @@ format.
 
 Changelog:
 
+2023-07-31 ryangray
+        * Fix bug of numbers after a + or - which followed a $ didn't include
+          the inline floating point bytes (such as: CODE a$-32)
+        * Version 1.8.5
+
 2023-07-07 ryangray
         * Fix bug not ending the in_deffn condition which would produce a bad 
           line or cause zmakebas to hang.
+        * Version 1.8.4
 
 2023-04-15 ryangray
         * Fix "-num" or "+num" following a number leaving out the FP bytes after "num"


### PR DESCRIPTION
Since we were parsing a number at a leading '+' or '-' rather than at the digit or leading '.', then a '$' before the '+' or '-' that is part of an expression (such as "CODE a$-32") was erroneously recognized as a "$nnnn" Spectrum Next hex constant and leaving out the floating point bytes. The fix was to change the number parsing to start on the digit or a leading '.', leaving the leading '+' or '-' to just copy through as it is not part of the FP number.

I did run it on the zx-next-demo.bas file and checked that the hex and binary constants were not getting FP bytes as expected.